### PR TITLE
Fix stackoverflow when getting user settings JIRA DYN-1052

### DIFF
--- a/src/context/GlobalContext.ts
+++ b/src/context/GlobalContext.ts
@@ -18,7 +18,7 @@ abstract class Context<TClientContext extends IClientContext> {
         protected readonly innerUserSettings: IUserSettings) { }
 
     get client(): IClientContext { return this.clientContext; }
-    get userSettings() { return this.userSettings; }
+    get userSettings() { return this.innerUserSettings; }
 }
 
 interface INullGlobalContextOptions {


### PR DESCRIPTION
This issue was introduced by coveo-xrm@0.3.1. There is a stack overflow when calling `context.userSettings`.